### PR TITLE
Change AttachmentData.init to public.

### DIFF
--- a/Sources/SwiftUIMessage/MFMailComposeViewController/MailComposeView+ViewModifiers.swift
+++ b/Sources/SwiftUIMessage/MFMailComposeViewController/MailComposeView+ViewModifiers.swift
@@ -30,12 +30,12 @@ extension MailComposeView {
         }
         
         /// The data to attach. Typically, this is the contents of a file that you want to include.
-        var attachment: Data
+        public var attachment: Data
         
         /// The MIME type of the specified data. (For example, the MIME type for a JPEG image is `image/jpeg`.) For a list of valid MIME types, see [http://www.iana.org/assignments/media-types/](http://www.iana.org/assignments/media-types/).
-        var mimeType: String
+        public var mimeType: String
         
         /// The preferred filename to associate with the data. This is the default name applied to the file when it is transferred to its destination. Any path separator (/) characters in the filename are converted to underscore (\_) characters prior to transmission.
-        var fileName: String
+        public var fileName: String
     }
 }

--- a/Sources/SwiftUIMessage/MFMailComposeViewController/MailComposeView+ViewModifiers.swift
+++ b/Sources/SwiftUIMessage/MFMailComposeViewController/MailComposeView+ViewModifiers.swift
@@ -23,6 +23,12 @@ extension MailComposeView {
     ///
     /// - Note: You may attach multiple files (using different file names).
     public struct AttachmentData {
+        public init(attachment: Data, mimeType: String, fileName: String) {
+            self.attachment = attachment
+            self.mimeType = mimeType
+            self.fileName = fileName
+        }
+        
         /// The data to attach. Typically, this is the contents of a file that you want to include.
         var attachment: Data
         


### PR DESCRIPTION
It's impossible to make `AttachmentData` structs outside of the package library because the default constructor is scoped `internal`. This adds an explicit public constructor to allow code like `MailComposeView().withAttachments(logAttachment` to build in external targets.